### PR TITLE
Updated missing {global_or_local, local}

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -33,6 +33,7 @@ edit src/eredis_pool.app.src
    {mod, { eredis_pool_app, []}},
    {env, [
            {pools, [
+                    {global_or_local, local},
                     {default, [
                                {size, 10},
                                {max_overflow, 20}


### PR DESCRIPTION
{global_or_local, local} or {global_or_local, global}.

If global, then eredis_pool:qp({global,dbsrv}, Pipeline).   Otherwise eredis_pool:qp(dbsrv, Pipeline).
