### PR TITLE
Add missing dependencies and support for git tags

### DIFF
--- a/src/eredis_pool.app.src
+++ b/src/eredis_pool.app.src
@@ -5,7 +5,9 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  poolboy,
+                  eredis
                  ]},
   {mod, { eredis_pool_app, []}},
   {env, []}

--- a/src/eredis_pool.app.src
+++ b/src/eredis_pool.app.src
@@ -1,7 +1,7 @@
 {application, eredis_pool,
  [
   {description, ""},
-  {vsn, "1.1"},
+  {vsn, git},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
Just a tiny patch to add missing dependencies on eredis and poolboy, and to retrieve the application version from the git tag (which should be added).